### PR TITLE
Fixed the tab change issue due to page reload

### DIFF
--- a/STTApplication/src/main/java/com/build/labs/controller/STTController.java
+++ b/STTApplication/src/main/java/com/build/labs/controller/STTController.java
@@ -107,6 +107,7 @@ public class STTController {
 
 		List<Output> outputList = formatOutput(transcript);
 		model.addAttribute("result", outputList);
+		model.addAttribute("tabValue", "panel-4");
 		return "index";
 
 	}

--- a/STTApplication/src/main/resources/templates/index.html
+++ b/STTApplication/src/main/resources/templates/index.html
@@ -75,7 +75,7 @@
 		<div class="bx--row">
 			<div class="bx--col-sm-4 bx--col-lg-12" style="margin: 6rem 0;">
 
-				<bx-tabs trigger-content="Select an item" value="panel-1">
+				<bx-tabs trigger-content="Select an item" th:value="${tabValue ne null ? tabValue : 'panel-1'}">
 					<bx-tab id="sample-audio" target="panel-1" value="panel-1">Sample Audio</bx-tab>
 					<bx-tab id="sample-audio-param" target="panel-4" value="panel-4">Audio with Parameter</bx-tab>
 					<bx-tab id="upload-your-audio" target="panel-2" value="panel-2">Upload Your Audio</bx-tab>


### PR DESCRIPTION
Fixed the tab change issue due to page reload

Issue:
when user tries the 'convert' feature from 'Audio with parameters' tab, the backend return the index page hence putting the user back on first tab! User then need to go to 2nd tab manually to see the results.